### PR TITLE
Cabal 1.18 makes a breaking change. Fix Setup.lhs so it configures, builds, and installs.

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -24,10 +24,7 @@
 >     } 
 > }
 > 
-> gslconfigProgram = (simpleProgram "gsl-config") {
->     programFindLocation = \verbosity ->
->       findProgramLocation verbosity "gsl-config"
->   }
+> gslconfigProgram = (simpleProgram "gsl-config")
 > 
 > gslBuildInfo :: LocalBuildInfo -> IO BuildInfo
 > gslBuildInfo lbi = do


### PR DESCRIPTION
However, we no longer need to feed in our own function anymore since `simpleProgram` handles it.
To solve patperry/hs-gsl-random#5
